### PR TITLE
[Address] Refactor dockercompose address / port assignment logic

### DIFF
--- a/blueprint/pkg/coreplugins/address/portassignment.go
+++ b/blueprint/pkg/coreplugins/address/portassignment.go
@@ -1,105 +1,87 @@
 package address
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/blueprint-uservices/blueprint/blueprint/pkg/blueprint"
 	"github.com/blueprint-uservices/blueprint/blueprint/pkg/ir"
 )
 
-/*
-AssignPorts is a helper method intended for use by namespace nodes when they
-are compiling code and concrete ports must be assigned to [BindConfig] IR nodes.
+// Removes and returns all [BindConfig] and [DialConfig] nodes from the provided list of nodes,
+// as well as the remaining nodes.
+func Split(nodes []ir.IRNode) (binds []*BindConfig, dials []*DialConfig, remaining []ir.IRNode) {
+	for _, node := range nodes {
+		switch n := node.(type) {
+		case *BindConfig:
+			binds = append(binds, n)
+		case *DialConfig:
+			dials = append(dials, n)
+		default:
+			remaining = append(remaining, node)
+		}
+	}
+	return
+}
 
-The provided nodes can be any IR nodes; this method will filter out only the [BindConfig]
-nodes.
+// Assigns the provided hostname to all [BindConfig] nodes in the provided list of nodes.
+func SetHostname(hostname string, nodes []*BindConfig) {
+	for _, addr := range nodes {
+		addr.Hostname = hostname
+	}
+}
 
-Some of the provided nodes might already be assigned to a particular port.  This method
-will not change those port assignments, though it will return an error if two nodes
-are already pre-assigned to the same port.
+// Removes the hostname and port assignments from a node
+func Clear(binds []*BindConfig) {
+	for _, bind := range binds {
+		bind.Hostname = ""
+		bind.Port = 0
+	}
+}
 
-Ports will be assigned either ascending from port 2000, or ascending from a node's
-preferred port if a preference was specified.
-
-After calling this method, any provided [BindConfig] IR nodes will have their hostname
-and port set.
-*/
-func AssignPorts(hostname string, nodes []ir.IRNode) error {
-	// Extract the BindConfig nodes
-	addrs := ir.Filter[*BindConfig](nodes)
-
+// For any of the provided [BindConfig] nodes, if they have not already got a port assigned
+// to them, then this method will assign a port.  Ports will be assigned so as not to use
+// any port already assigned.  If the same port has been assigned multiple times already,
+// an error will be returned.
+//
+// Ports will be assigned using the PreferredPort field.
+//
+// Returns preassigned, the list of [BindConfig] nodes that already had a port assigned;
+// assigned, the list of [BindConfig] nodes that were assigned a port; and
+// err if there was a collision in the preassigned ports
+func AssignPorts(binds []*BindConfig) (preassigned []*BindConfig, assigned []*BindConfig, err error) {
 	ports := make(map[uint16]*BindConfig)
 
 	// Save any pre-assigned ports
-	for _, addr := range addrs {
-		if addr.Port != 0 {
-			if other, conflict := ports[addr.Port]; conflict {
-				return blueprint.Errorf("%v and %v both pre-assigned to port %v", other.Name(), addr.Name(), addr.Port)
+	for _, bind := range binds {
+		if bind.Port != 0 {
+			if other, conflict := ports[bind.Port]; conflict {
+				err = blueprint.Errorf("%v and %v both pre-assigned to port %v", other.Name(), bind.Name(), bind.Port)
+				return
 			}
-			ports[addr.Port] = addr
-		}
-	}
-
-	// Assign preferred ports first
-	for _, addr := range addrs {
-		if addr.Port == 0 && addr.PreferredPort != 0 {
-			if _, conflict := ports[addr.PreferredPort]; !conflict {
-				addr.Port = addr.PreferredPort
-				addr.Hostname = hostname
-				ports[addr.Port] = addr
-			}
+			ports[bind.Port] = bind
+			preassigned = append(preassigned, bind)
+		} else {
+			assigned = append(assigned, bind)
 		}
 	}
 
 	// Assign remaining ports
-	for _, addr := range addrs {
-		if addr.Port == 0 {
-			candidatePort := addr.PreferredPort
-			if candidatePort == 0 {
-				candidatePort = 2000
+	for _, addr := range assigned {
+		candidatePort := addr.PreferredPort
+		if candidatePort == 0 {
+			candidatePort = 2000
+		}
+		for {
+			if _, alreadyAssigned := ports[candidatePort]; !alreadyAssigned {
+				addr.Port = candidatePort
+				ports[addr.Port] = addr
+				break
 			}
-			for {
-				if _, alreadyAssigned := ports[candidatePort]; !alreadyAssigned {
-					addr.Port = candidatePort
-					addr.Hostname = hostname
-					ports[addr.Port] = addr
-					break
-				}
-				candidatePort++
-			}
-
+			candidatePort++
 		}
 	}
 
-	// Update preferred ports
-	for _, addr := range addrs {
-		addr.PreferredPort = addr.Port
+	// Set the preferred ports of all addresses
+	for _, bind := range binds {
+		bind.PreferredPort = bind.Port
 	}
-	return nil
-}
-
-// Returns an error if there are [BindConfig] nodes in the provided list that haven't been allocated a port.
-func CheckPorts(nodes []ir.IRNode) error {
-	var missing []string
-	for _, addr := range ir.Filter[*BindConfig](nodes) {
-		if addr.Port == 0 {
-			missing = append(missing, addr.Name())
-		}
-	}
-	if len(missing) > 0 {
-		return fmt.Errorf("unassigned bind addresses %v", strings.Join(missing, ", "))
-	}
-	return nil
-}
-
-// Clears the hostname and port from any [BindConfig] node.
-//
-// This is used by namespace nodes when performing address translation, e.g. between
-// ports within a container vs. external to a container.
-func ResetPorts(nodes []ir.IRNode) {
-	for _, addr := range ir.Filter[*BindConfig](nodes) {
-		addr.Port = 0
-		addr.Hostname = ""
-	}
+	return
 }

--- a/blueprint/pkg/ir/irutil.go
+++ b/blueprint/pkg/ir/irutil.go
@@ -34,6 +34,19 @@ func Filter[T any](nodes []IRNode) []T {
 	return ts
 }
 
+// Returns a slice containing only nodes of type T,
+// and a slice containing all other nodes
+func Split[T any](nodes []IRNode) (remaining []IRNode, matches []T) {
+	for _, node := range nodes {
+		if t, isT := node.(T); isT {
+			matches = append(matches, t)
+		} else {
+			remaining = append(remaining, node)
+		}
+	}
+	return
+}
+
 // Returns a slice containing only nodes of type T
 func FilterNodes[T any](nodes []IRNode) []IRNode {
 	var ts []IRNode

--- a/plugins/dockercompose/deploy.go
+++ b/plugins/dockercompose/deploy.go
@@ -3,6 +3,7 @@ package dockercompose
 import (
 	"fmt"
 	"path/filepath"
+	"reflect"
 
 	"github.com/blueprint-uservices/blueprint/blueprint/pkg/blueprint"
 	"github.com/blueprint-uservices/blueprint/blueprint/pkg/blueprint/ioutil"
@@ -40,7 +41,8 @@ type (
 
 		info docker.ContainerWorkspaceInfo
 
-		ImageDirs map[string]string // map from image name to directory
+		ImageDirs    map[string]string      // map from image name to directory
+		InstanceArgs map[string][]ir.IRNode // argnodes for each instance added to the workspace
 
 		DockerComposeFile *dockergen.DockerComposeFile
 	}
@@ -77,9 +79,6 @@ func (node *Deployment) generateArtifacts(workspace *dockerComposeWorkspace) err
 		return err
 	}
 
-	// Reset any port assignments for externally-visible servers, since they will currently
-	// be assigned to docker-internal ports
-	address.ResetPorts(node.Edges)
 	return nil
 }
 
@@ -90,6 +89,7 @@ func NewDockerComposeWorkspace(name string, dir string) *dockerComposeWorkspace 
 			Target: "docker-compose",
 		},
 		ImageDirs:         make(map[string]string),
+		InstanceArgs:      make(map[string][]ir.IRNode),
 		DockerComposeFile: dockergen.NewDockerComposeFile(name, dir, "docker-compose.yml"),
 	}
 }
@@ -110,22 +110,14 @@ func (d *dockerComposeWorkspace) CreateImageDir(imageName string) (string, error
 
 // Implements docker.ContainerWorkspace
 func (d *dockerComposeWorkspace) DeclarePrebuiltInstance(instanceName string, image string, args ...ir.IRNode) error {
-	// Docker containers should assign all internal server ports (typically using address.AssignPorts) before adding an instance
-	if err := address.CheckPorts(args); err != nil {
-		return blueprint.Errorf("unable to add docker instance %v due to %v", instanceName, err.Error())
-	}
-
-	return d.DockerComposeFile.AddImageInstance(instanceName, image, args...)
+	d.InstanceArgs[instanceName] = args
+	return d.DockerComposeFile.AddImageInstance(instanceName, image)
 }
 
 // Implements docker.ContainerWorkspace
 func (d *dockerComposeWorkspace) DeclareLocalImage(instanceName string, imageDir string, args ...ir.IRNode) error {
-	// Docker containers should assign all internal server ports (typically using address.AssignPorts) before adding an instance
-	if err := address.CheckPorts(args); err != nil {
-		return blueprint.Errorf("unable to add docker instance %v due to %v", instanceName, err.Error())
-	}
-
-	return d.DockerComposeFile.AddBuildInstance(instanceName, imageDir, args...)
+	d.InstanceArgs[instanceName] = args
+	return d.DockerComposeFile.AddBuildInstance(instanceName, imageDir)
 }
 
 // Implements docker.ContainerWorkspace
@@ -135,8 +127,92 @@ func (d *dockerComposeWorkspace) SetEnvironmentVariable(instanceName string, key
 
 // Generates the docker-compose file
 func (d *dockerComposeWorkspace) Finish() error {
+	// We didn't set any arguments or environment variables while accumulating instances. Do so now.
+	if err := d.processArgNodes(); err != nil {
+		return err
+	}
+
 	// Now that all images and instances have been declared, we can generate the docker-compose file
 	return d.DockerComposeFile.Generate()
+}
+
+// Goes through each container's arg nodes, determining which need to be passed to the container
+// as environment variables.
+//
+// Has special handling for addresses; containers that bind a server will have ports assigned,
+// and containers that dial to a server within this namespace will have the dial address set.
+//
+// We don't pick external-facing ports for any addresses; these will be set by the caller or user.
+func (d *dockerComposeWorkspace) processArgNodes() error {
+	addresses := make(map[string]string)
+	for instanceName, instanceArgs := range d.InstanceArgs {
+		binds, _, remaining := address.Split(instanceArgs)
+
+		// First handle the non-address arguments to the node, which will need to be passed
+		// through as environment variables.
+		// The only special handling is that if a config node already has a value set on it,
+		// then we don't need to pass the value at all, because we can assume that the value
+		// will be hard-coded inside the container.
+		for _, arg := range remaining {
+			switch node := arg.(type) {
+			case ir.IRConfig:
+				if !node.HasValue() {
+					d.DockerComposeFile.PassthroughEnvVar(instanceName, node.Name(), node.Optional())
+				}
+			default:
+				return blueprint.Errorf("container instance %v can only accept IRConfig nodes as arguments, but found %v of type %v", instanceName, arg, reflect.TypeOf(arg))
+			}
+		}
+
+		// Some of the ports within this container might not yet be assigned; do so now.
+		// Any ports that we assign will need to be passed into the container as environment
+		// variables so that the server knows what port to bind to.
+		_, assigned, err := address.AssignPorts(binds)
+		if err != nil {
+			return err
+		}
+		for _, bind := range assigned {
+			d.DockerComposeFile.AddEnvVar(instanceName, bind.Name(), fmt.Sprintf("0.0.0.0:%v", bind.Port))
+		}
+
+		// All ports need to be exposed in the docker-compose file in order to be accessible
+		// to other containers.
+		for _, bind := range binds {
+			d.DockerComposeFile.ExposePort(instanceName, bind.Port)
+			d.DockerComposeFile.MapPortToEnvVar(instanceName, bind.Port, bind.Name())
+		}
+
+		// Save the addresses that are bound in this container instance, so that in a moment
+		// we can set the dial addresses for any other containers that want to dial this serer
+		for _, bind := range binds {
+			hostname := ir.CleanName(instanceName)
+			addresses[bind.AddressName] = fmt.Sprintf("%v:%v", hostname, bind.Port)
+		}
+
+		// The default logic for the docker-compose file is for the user to set environment
+		// variables so that internal container ports are bound to external-facing ports on the
+		// host machine.  These ports are chosen by the user at runtime and set by env vars.
+		for _, bind := range binds {
+			d.DockerComposeFile.MapPortToEnvVar(instanceName, bind.Port, bind.Name())
+		}
+		address.Clear(binds)
+	}
+
+	// Now that we know the local addresses of all servers bound within this workspace, set
+	// all dials.  Dials to local servers can have the address set directly; dials to servers
+	// that don't exist within this workspace will need to be passed through as an env var.
+	for instanceName, instanceArgs := range d.InstanceArgs {
+		_, dials, _ := address.Split(instanceArgs)
+		for _, dial := range dials {
+			if addr, isLocalDial := addresses[dial.AddressName]; isLocalDial {
+				d.DockerComposeFile.AddEnvVar(instanceName, dial.Name(), addr)
+			} else {
+				d.DockerComposeFile.PassthroughEnvVar(instanceName, dial.Name(), false)
+			}
+		}
+	}
+
+	return nil
 }
 
 func (d *dockerComposeWorkspace) ImplementsBuildContext()       {}

--- a/plugins/dockercompose/deploy.go
+++ b/plugins/dockercompose/deploy.go
@@ -176,17 +176,12 @@ func (d *dockerComposeWorkspace) processArgNodes() error {
 		}
 
 		// All ports need to be exposed in the docker-compose file in order to be accessible
-		// to other containers.
-		for _, bind := range binds {
-			d.DockerComposeFile.ExposePort(instanceName, bind.Port)
-			d.DockerComposeFile.MapPortToEnvVar(instanceName, bind.Port, bind.Name())
-		}
-
-		// Save the addresses that are bound in this container instance, so that in a moment
-		// we can set the dial addresses for any other containers that want to dial this serer
+		// to other containers.  We then save the addresses so that other containers can dial
+		// to them.
 		for _, bind := range binds {
 			hostname := ir.CleanName(instanceName)
 			addresses[bind.AddressName] = fmt.Sprintf("%v:%v", hostname, bind.Port)
+			d.DockerComposeFile.ExposePort(instanceName, bind.Port)
 		}
 
 		// The default logic for the docker-compose file is for the user to set environment

--- a/plugins/dockercompose/dockergen/dockercompose.go
+++ b/plugins/dockercompose/dockergen/dockercompose.go
@@ -19,7 +19,7 @@ type DockerComposeFile struct {
 	WorkspaceDir  string
 	FileName      string
 	FilePath      string
-	Instances     map[string]instance            // Container instance declarations
+	Instances     map[string]*instance           // Container instance declarations
 	localServers  map[string]*address.BindConfig // Servers that have been defined within this docker-compose file
 	localDials    map[string]*address.DialConfig // All servers that will be dialed from within this docker-compose file
 }
@@ -29,6 +29,7 @@ type instance struct {
 	ContainerTemplate string              // only used if built; empty if not
 	Image             string              // only used by prebuilt; empty if not
 	Ports             map[string]uint16   // Map from bindconfig name to internal port
+	Expose            map[uint16]struct{} // Ports exposed with expose directive
 	Config            map[string]string   // Map from environment variable name to value
 	Passthrough       map[string]struct{} // Environment variables that just get passed through to the container
 }
@@ -39,40 +40,95 @@ func NewDockerComposeFile(workspaceName, workspaceDir, fileName string) *DockerC
 		WorkspaceDir:  workspaceDir,
 		FileName:      fileName,
 		FilePath:      filepath.Join(workspaceDir, fileName),
-		Instances:     make(map[string]instance),
+		Instances:     make(map[string]*instance),
 		localServers:  make(map[string]*address.BindConfig),
 		localDials:    make(map[string]*address.DialConfig),
 	}
 }
 
 func (d *DockerComposeFile) Generate() error {
-	// Point any local dials directly to the local server
-	d.ResolveLocalDials()
 	slog.Info(fmt.Sprintf("Generating %v/%v", d.WorkspaceName, d.FileName))
 	return ExecuteTemplateToFile("docker-compose", dockercomposeTemplate, d, d.FilePath)
 
 }
 
-func (d *DockerComposeFile) AddImageInstance(instanceName string, image string, args ...ir.IRNode) error {
-	return d.addInstance(instanceName, image, "", args...)
+// Adds an instance to the docker-compose file, that will use an off-the-shelf image.
+//
+// The instanceName is chosen by the user; it can subsequently be passed in methods such as [AddEnvVar],
+// [PassthroughEnvVar], [ExposePort], [MapPort], and [MapPortToEnvVar].
+func (d *DockerComposeFile) AddImageInstance(instanceName string, image string) error {
+	return d.addInstance(instanceName, image, "")
 }
 
-func (d *DockerComposeFile) AddBuildInstance(instanceName string, containerTemplateName string, args ...ir.IRNode) error {
-	return d.addInstance(instanceName, "", containerTemplateName, args...)
+// Adds an instance to the docker-compose file, that will be built from a container template
+// on the local filesystem
+//
+// The instanceName is chosen by the user; it can subsequently be passed in methods such as [AddEnvVar],
+// [PassthroughEnvVar], [ExposePort], [MapPort], and [MapPortToEnvVar].
+func (d *DockerComposeFile) AddBuildInstance(instanceName string, containerTemplateName string) error {
+	return d.addInstance(instanceName, "", containerTemplateName)
 }
 
-func (d *DockerComposeFile) AddEnvVar(instanceName string, key string, val string) error {
+func (d *DockerComposeFile) getInstance(instanceName string) (*instance, error) {
 	instanceName = ir.CleanName(instanceName)
-	if i, exists := d.Instances[instanceName]; !exists {
-		return blueprint.Errorf("container instance with name %v not found", instanceName)
-	} else {
-		i.Config[key] = val
-		d.Instances[instanceName] = i
+	if i, exists := d.Instances[instanceName]; exists {
+		return i, nil
 	}
+	return nil, blueprint.Errorf("container instance with name %v not found", instanceName)
+}
+
+// Sets an environment variable key to the specified val for instanceName
+func (d *DockerComposeFile) AddEnvVar(instanceName string, key string, val string) error {
+	instance, err := d.getInstance(instanceName)
+	if err != nil {
+		return err
+	}
+	key = linux.EnvVar(key)
+	instance.Config[key] = val
 	return nil
 }
 
-func (d *DockerComposeFile) addInstance(instanceName string, image string, containerTemplateName string, args ...ir.IRNode) error {
+// Pass through the specified environment variable key from the calling environment
+func (d *DockerComposeFile) PassthroughEnvVar(instanceName string, key string, optional bool) error {
+	var passthroughValue string
+	if optional {
+		passthroughValue = fmt.Sprintf("${%v:-}", linux.EnvVar(key))
+	} else {
+		passthroughValue = fmt.Sprintf("${%v?%v must be set by the calling environment}", linux.EnvVar(key), key)
+	}
+	return d.AddEnvVar(instanceName, key, passthroughValue)
+}
+
+// Exposes a container-internal port for use by other containers within the docker-compose file
+func (d *DockerComposeFile) ExposePort(instanceName string, internalPort uint16) error {
+	instance, err := d.getInstance(instanceName)
+	if err != nil {
+		return err
+	}
+	instance.Expose[internalPort] = struct{}{}
+	return nil
+}
+
+// Further to [ExposePort], adds a Port directive so that the host machine can access the internalPort
+// of the container via the externalAddress.  Typically externalAddress will be a localhost or 0.0.0.0
+// address
+func (d *DockerComposeFile) MapPort(instanceName string, internalPort uint16, externalAddress string) error {
+	instance, err := d.getInstance(instanceName)
+	if err != nil {
+		return err
+	}
+	instance.Ports[externalAddress] = internalPort
+	return nil
+}
+
+// Further to [ExposePort], adds a Port directive so that the host machine can access the internalPort
+// of the container, using a runtime substitution of envVarName as the externalAddress
+func (d *DockerComposeFile) MapPortToEnvVar(instanceName string, internalPort uint16, envVarName string) error {
+	externalAddress := fmt.Sprintf("${%v?%v must be set by the calling environment}", linux.EnvVar(envVarName), envVarName)
+	return d.MapPort(instanceName, internalPort, externalAddress)
+}
+
+func (d *DockerComposeFile) addInstance(instanceName string, image string, containerTemplateName string) error {
 	instanceName = ir.CleanName(instanceName)
 	if _, exists := d.Instances[instanceName]; exists {
 		return blueprint.Errorf("re-declaration of container instance %v of image %v", instanceName, image)
@@ -81,77 +137,13 @@ func (d *DockerComposeFile) addInstance(instanceName string, image string, conta
 		InstanceName:      instanceName,
 		ContainerTemplate: containerTemplateName,
 		Image:             image,
+		Expose:            make(map[uint16]struct{}),
 		Ports:             make(map[string]uint16),
 		Config:            make(map[string]string),
 		Passthrough:       make(map[string]struct{}),
 	}
-	for _, node := range args {
-		varname := linux.EnvVar(node.Name())
-
-		// TODO: only the server addrs that get passed in as node args to the docker deployment actually need to be included
-		//    in the docker-compose ports section; the remainder only need to be exposed to containers within the deployment
-		//    but not to the outsdie world
-
-		// Docker containers should assign all internal server ports (typically using address.AssignPorts) before adding an instance
-		if bind, isBindConfig := node.(*address.BindConfig); isBindConfig {
-			if bind.Port == 0 {
-				return fmt.Errorf("cannot add docker instance %v due to unbound server port %v", instanceName, bind.Name())
-			}
-			instance.Ports[requiredEnvVar(node)] = bind.Port
-			bind.Hostname = instanceName
-		}
-
-		if conf, isConfig := node.(ir.IRConfig); isConfig {
-			if conf.HasValue() {
-				instance.Config[varname] = conf.Value()
-				continue
-			} else if conf.Optional() {
-				instance.Passthrough[varname] = struct{}{}
-				continue
-			}
-		}
-		instance.Config[varname] = requiredEnvVar(node)
-	}
-	d.Instances[instanceName] = instance
-
-	// Save all the dial and binds that we see; before compiling the docker-compose, we'll link them up to each other
-	d.checkForAddrs(args)
-
+	d.Instances[instanceName] = &instance
 	return nil
-}
-
-func (d *DockerComposeFile) checkForAddrs(nodes []ir.IRNode) {
-	for _, node := range nodes {
-		switch c := node.(type) {
-		case *address.BindConfig:
-			d.localServers[c.AddressName] = c
-		case *address.DialConfig:
-			d.localDials[c.AddressName] = c
-		}
-	}
-}
-
-func (d *DockerComposeFile) ResolveLocalDials() error {
-	for name, bind := range d.localServers {
-		dial, hasLocalDial := d.localDials[name]
-		if !hasLocalDial {
-			continue
-		}
-
-		// Update the configured value for any instance that uses this dial addr
-		// to point it directly towards the local server
-		dialVarname := linux.EnvVar(dial.Name())
-		for _, instance := range d.Instances {
-			if _, hasConfig := instance.Config[dialVarname]; hasConfig {
-				instance.Config[dialVarname] = bind.Value()
-			}
-		}
-	}
-	return nil
-}
-
-func requiredEnvVar(node ir.IRNode) string {
-	return fmt.Sprintf("${%v?%v must be set by the calling environment}", linux.EnvVar(node.Name()), node.Name())
 }
 
 var dockercomposeTemplate = `
@@ -169,7 +161,7 @@ services:
     hostname: {{.InstanceName}}
     {{- if .Ports}}
     expose:
-    {{- range $_, $internal := .Ports}}
+    {{- range $internal, $_ := .Expose}}
      - "{{$internal}}"
     {{- end}}
     ports:
@@ -182,7 +174,7 @@ services:
     {{- range $name, $value := .Config}}
      - {{$name}}={{$value}}
     {{- end}}
-    restart: always
     {{- end}}
+    restart: always
 {{end}}
 `

--- a/plugins/linuxcontainer/deploy_docker.go
+++ b/plugins/linuxcontainer/deploy_docker.go
@@ -3,7 +3,6 @@ package linuxcontainer
 import (
 	"fmt"
 
-	"github.com/blueprint-uservices/blueprint/blueprint/pkg/coreplugins/address"
 	"github.com/blueprint-uservices/blueprint/plugins/docker"
 	"github.com/blueprint-uservices/blueprint/plugins/linuxcontainer/dockergen"
 	"golang.org/x/exp/slog"
@@ -81,11 +80,6 @@ func (node *Container) AddContainerInstance(target docker.ContainerWorkspace) er
 	// The instance only needs to be added to the output directory once
 	if target.Visited(node.InstanceName + ".instance") {
 		return nil
-	}
-
-	// Assign ports to addresses that are bound inside this container
-	if err := address.AssignPorts(node.InstanceName, append(node.Nodes, node.Edges...)); err != nil {
-		return err
 	}
 
 	slog.Info(fmt.Sprintf("Declaring container instance %v", node.InstanceName))


### PR DESCRIPTION
Cleans up the port assignment logic in the docker compose workspace, to put it all in one location and make it clearer about what's happening.

