### PR TITLE
Update go version in generated mod files to go1.21

### DIFF
--- a/plugins/golang/gogen/workspacebuilder.go
+++ b/plugins/golang/gogen/workspacebuilder.go
@@ -91,7 +91,7 @@ func (workspace *WorkspaceBuilderImpl) CreateModule(moduleName string, moduleVer
 	workspace.GeneratedModules[moduleShortName] = moduleName
 
 	// Create the go.mod file
-	modfileContents := fmt.Sprintf("module %v\n\ngo 1.20", moduleName)
+	modfileContents := fmt.Sprintf("module %v\n\ngo 1.21", moduleName)
 	modfile := filepath.Join(moduleDir, "go.mod")
 
 	return moduleDir, os.WriteFile(modfile, []byte(modfileContents), 0755)
@@ -167,7 +167,7 @@ func (workspace *WorkspaceBuilderImpl) readModfile(moduleSubDir string) (*modfil
 	return f, nil
 }
 
-var goWorkTemplate = `go 1.20
+var goWorkTemplate = `go 1.21
 
 use (
 	{{ range $dirName, $moduleName := .Modules }}./{{ $dirName }}

--- a/plugins/goproc/linuxgen/dockerfile_buildcommands.go
+++ b/plugins/goproc/linuxgen/dockerfile_buildcommands.go
@@ -22,7 +22,7 @@ var dockerfileBuildTemplate = `
 #  custom docker build commands provided by goproc.Process {{.ProcName}}
 #
 
-FROM golang:1.20-bookworm AS {{.ProcName}}
+FROM golang:1.21.8-alpine AS {{.ProcName}}
 
 COPY ./{{.ProcName}} /src
 


### PR DESCRIPTION
If Blueprint is being used with go1.22 then running `go mod download` as part of the build process to add a `toolchain` directive to the generated `go.mod` files. This `toolchain` directive is something that old versions of Go (<1.21) cannot parse which results in errors when building docker containers.
Upgrading the go version to 1.21 in the generated code is a simple fix for this issue.