### PR TITLE
[Core] Rename ptr src and dst to client and server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vs
+build

--- a/blueprint/pkg/coreplugins/namespaceutil/namespace.go
+++ b/blueprint/pkg/coreplugins/namespaceutil/namespace.go
@@ -55,7 +55,7 @@ func AddNodeTo[NamespaceNodeType any](spec wiring.WiringSpec, namespaceName stri
 	// Unlike most modifiers, we don't want this modifier to change which node the client side of the
 	// pointer receives
 	modifierName := fmt.Sprintf("%v.%v", childName, namespaceName)
-	ptrNext := ptr.AddDstModifier(spec, modifierName, pointer.ModifierOpts{IsInterfaceNode: false})
+	ptrNext := ptr.AddServerModifier(spec, modifierName, pointer.ModifierOpts{IsInterfaceNode: false})
 
 	// We are proxying the ptrNext node, so must provide wiring spec options
 	ptrNextDef := spec.GetDef(ptrNext)

--- a/blueprint/pkg/coreplugins/pointer/pointer.go
+++ b/blueprint/pkg/coreplugins/pointer/pointer.go
@@ -153,11 +153,11 @@ func GetPointer(spec wiring.WiringSpec, name string) *PointerDef {
 // to add functionality like tracing, or to make calls over RPC.
 //
 // A pointer can have multiple modifiers applied to it.  They will be applied in the order
-// that AddSrcModifier was called.
+// that AddClientModifier was called.
 //
-// The return value of AddSrcModifier is the name of the _next_ client side modifier.  This
+// The return value of AddClientModifier is the name of the _next_ client side modifier.  This
 // can be used within the BuildFunc of modifierName.
-func (ptr *PointerDef) AddSrcModifier(spec wiring.WiringSpec, modifierName string) string {
+func (ptr *PointerDef) AddClientModifier(spec wiring.WiringSpec, modifierName string) string {
 	spec.Alias(ptr.clientTail, modifierName)
 	ptr.clientTail = modifierName + ".ptr.src.next"
 	spec.Alias(ptr.clientTail, ptr.interfaceNode)

--- a/blueprint/pkg/coreplugins/pointer/pointer.go
+++ b/blueprint/pkg/coreplugins/pointer/pointer.go
@@ -172,11 +172,11 @@ func (ptr *PointerDef) AddClientModifier(spec wiring.WiringSpec, modifierName st
 // to add functionality like tracing, or to deploy a service with RPC.
 //
 // A pointer can have multiple modifiers applied to it.  They will be applied in the order
-// that AddDstModifier was caleld.
+// that AddServerModifier was caleld.
 //
-// The return value of AddDstModifier is the name of the _previous_ server side modifier.  This
+// The return value of AddServerModifier is the name of the _previous_ server side modifier.  This
 // can be used within the BuildFunc of modifierName.
-func (ptr *PointerDef) AddDstModifier(spec wiring.WiringSpec, modifierName string, options ...ModifierOpts) string {
+func (ptr *PointerDef) AddServerModifier(spec wiring.WiringSpec, modifierName string, options ...ModifierOpts) string {
 	opts := defaultModifierOpts
 	if len(options) > 0 {
 		opts = options[0]
@@ -206,7 +206,7 @@ func (ptr *PointerDef) AddAddrModifier(spec wiring.WiringSpec, addrName string) 
 	}
 
 	// Add a modifier to instantiate address PointsTo
-	nextServer := ptr.AddDstModifier(spec, def.PointsTo)
+	nextServer := ptr.AddServerModifier(spec, def.PointsTo)
 
 	// Set the pointer interface to be the address, rather than the node
 	ptr.interfaceNode = addrName

--- a/blueprint/pkg/coreplugins/pointer/pointer.go
+++ b/blueprint/pkg/coreplugins/pointer/pointer.go
@@ -127,7 +127,7 @@ func CreatePointer[ClientNodeType any](spec wiring.WiringSpec, name string, serv
 		// This is the lazy implicit instantiation of the server side of the pointer, if
 		// it hasn't explicitly been instantiated somewhere in the wiring spec.
 		namespace.Defer(func() error {
-			return ptr.InstantiateDst(namespace)
+			return ptr.InstantiateServer(namespace)
 		}, wiring.DeferOpts{Front: false})
 
 		var node ir.IRNode
@@ -218,7 +218,7 @@ func (ptr *PointerDef) AddAddrModifier(spec wiring.WiringSpec, addrName string) 
 // If any pointer modifiers are addresses, this will instantiate the server side of the addresses.
 //
 // This is primarily used by namespace plugins.
-func (ptr *PointerDef) InstantiateDst(namespace wiring.Namespace) error {
+func (ptr *PointerDef) InstantiateServer(namespace wiring.Namespace) error {
 	namespace.Info("Instantiating pointer %s.server from namespace %s", ptr.name, namespace.Name())
 
 	// Instantiating server starts from the interface node between client and server

--- a/plugins/circuitbreaker/wiring.go
+++ b/plugins/circuitbreaker/wiring.go
@@ -28,7 +28,7 @@ func AddCircuitBreaker(spec wiring.WiringSpec, serviceName string, min_reqs int6
 		return
 	}
 
-	clientNext := ptr.AddSrcModifier(spec, clientWrapper)
+	clientNext := ptr.AddClientModifier(spec, clientWrapper)
 
 	spec.Define(clientWrapper, &CircuitBreakerClient{Min_Reqs: min_reqs, FailureRate: failure_rate}, func(ns wiring.Namespace) (ir.IRNode, error) {
 		var wrapped golang.Service

--- a/plugins/clientpool/wiring.go
+++ b/plugins/clientpool/wiring.go
@@ -56,7 +56,7 @@ func Create(spec wiring.WiringSpec, serviceName string, numClients int) {
 	}
 
 	// Add the client wrapper to the pointer src
-	clientNext := ptr.AddSrcModifier(spec, poolName)
+	clientNext := ptr.AddClientModifier(spec, poolName)
 
 	// Define the client pool
 	spec.Define(poolName, &ClientPool{}, func(namespace wiring.Namespace) (ir.IRNode, error) {

--- a/plugins/govector/wiring.go
+++ b/plugins/govector/wiring.go
@@ -80,7 +80,7 @@ func Instrument(spec wiring.WiringSpec, serviceName string) {
 		slog.Error("Unable to deploy " + serviceName + " using GoVector as it is not a pointer")
 	}
 
-	clientNext := ptr.AddSrcModifier(spec, clientWrapper)
+	clientNext := ptr.AddClientModifier(spec, clientWrapper)
 
 	spec.Define(clientWrapper, &GovecClientWrapper{}, func(ns wiring.Namespace) (ir.IRNode, error) {
 		var wrapped golang.Service

--- a/plugins/govector/wiring.go
+++ b/plugins/govector/wiring.go
@@ -90,7 +90,7 @@ func Instrument(spec wiring.WiringSpec, serviceName string) {
 		return newGovecClientWrapper(clientWrapper, wrapped)
 	})
 
-	serverNext := ptr.AddDstModifier(spec, serverWrapper)
+	serverNext := ptr.AddServerModifier(spec, serverWrapper)
 
 	spec.Define(serverWrapper, &GovecServerWrapper{}, func(ns wiring.Namespace) (ir.IRNode, error) {
 		var wrapped golang.Service

--- a/plugins/grpc/wiring.go
+++ b/plugins/grpc/wiring.go
@@ -93,7 +93,7 @@ func Deploy(spec wiring.WiringSpec, serviceName string) {
 	//
 	// The client-side modifier creates a gRPC client and dials the server address.
 	// It assumes the next src modifier node will be a golangServer address.
-	clientNext := ptr.AddSrcModifier(spec, grpcClient)
+	clientNext := ptr.AddClientModifier(spec, grpcClient)
 	spec.Define(grpcClient, &golangClient{}, func(namespace wiring.Namespace) (ir.IRNode, error) {
 		addr, err := address.Dial[*golangServer](namespace, clientNext)
 		if err != nil {

--- a/plugins/healthchecker/wiring.go
+++ b/plugins/healthchecker/wiring.go
@@ -17,22 +17,23 @@ import (
 // Uses a [blueprint.WiringSpec].
 // Usage:
 //
-//  AddHealthCheckAPI(spec, "serviceA")
+//	AddHealthCheckAPI(spec, "serviceA")
 //
 // Result:
-//  Old interface:
-//  type ServiceA interface {
-//     Method1(ctx context.Context, ...) (..., error)
-//     ...
-//     MethodN(ctx context.Context, ...) (..., error)
-//  }
-//  New interface:
-//  type ServiceAHealth interface {
-//     Method1(ctx context.Context, ...) (..., error)
-//     ...
-//     MethodN(ctx context.Context, ...) (..., error)
-//     Health(ctx context.Context) (string, error)
-//  }
+//
+//	Old interface:
+//	type ServiceA interface {
+//	   Method1(ctx context.Context, ...) (..., error)
+//	   ...
+//	   MethodN(ctx context.Context, ...) (..., error)
+//	}
+//	New interface:
+//	type ServiceAHealth interface {
+//	   Method1(ctx context.Context, ...) (..., error)
+//	   ...
+//	   MethodN(ctx context.Context, ...) (..., error)
+//	   Health(ctx context.Context) (string, error)
+//	}
 func AddHealthCheckAPI(spec wiring.WiringSpec, serviceName string) {
 	// The node that we are defining
 	serverWrapper := serviceName + ".server.hc"
@@ -45,7 +46,7 @@ func AddHealthCheckAPI(spec wiring.WiringSpec, serviceName string) {
 	}
 
 	// Add the server wrapper to the pointer dst
-	serverNext := ptr.AddDstModifier(spec, serverWrapper)
+	serverNext := ptr.AddServerModifier(spec, serverWrapper)
 
 	// Define the server wrapper
 	spec.Define(serverWrapper, &HealthCheckerServerWrapper{}, func(ns wiring.Namespace) (ir.IRNode, error) {

--- a/plugins/http/wiring.go
+++ b/plugins/http/wiring.go
@@ -52,7 +52,7 @@ func Deploy(spec wiring.WiringSpec, serviceName string) {
 	//
 	// The client-side modifier creates an HTTP client and dials the server address.
 	// It assumes that the next src modifier node will be a golangHttpServer address.
-	clientNext := ptr.AddSrcModifier(spec, httpClient)
+	clientNext := ptr.AddClientModifier(spec, httpClient)
 	spec.Define(httpClient, &GolangHttpClient{}, func(ns wiring.Namespace) (ir.IRNode, error) {
 		addr, err := address.Dial[*golangHttpServer](ns, clientNext)
 		if err != nil {

--- a/plugins/jaeger/wiring.go
+++ b/plugins/jaeger/wiring.go
@@ -64,7 +64,7 @@ func Collector(spec wiring.WiringSpec, collectorName string) string {
 	ptr.AddAddrModifier(spec, collectorAddr)
 
 	// Define the Jaeger client and add it to the client side of the pointer
-	clientNext := ptr.AddSrcModifier(spec, collectorClient)
+	clientNext := ptr.AddClientModifier(spec, collectorClient)
 	spec.Define(collectorClient, &JaegerCollectorClient{}, func(ns wiring.Namespace) (ir.IRNode, error) {
 		addr, err := address.Dial[*JaegerCollectorContainer](ns, clientNext)
 		if err != nil {

--- a/plugins/latency/wiring.go
+++ b/plugins/latency/wiring.go
@@ -5,8 +5,9 @@
 // The plugin will generate a wrapper class that will sleep for a fixed amount of time (the specified latency to be injected)
 // before invoking the handler for handling the request.
 // Example Usage to add 100ms latency to each request:
-//    import "github.com/blueprint-uservices/blueprint/plugins/latency"
-//    latency.AddFixed(spec, "my_service", "100ms")
+//
+//	import "github.com/blueprint-uservices/blueprint/plugins/latency"
+//	latency.AddFixed(spec, "my_service", "100ms")
 //
 // TODO: Allow latency to be injected selectively to a subset of requests based using
 // random sampling or by matching attributes of a request.
@@ -31,7 +32,8 @@ import (
 // Modifies the given service such that the server adds a fixed amount of `latency` while processing the request.
 // The `latency` string must be a sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h". Negative signed values such as "-1.5h" would result in no explicit latency being added; although it might result in the go runtime re-scheduling the running goroutine.
 // Usage:
-//   AddFixed(spec, "my_service", "100ms")
+//
+//	AddFixed(spec, "my_service", "100ms")
 func AddFixed(spec wiring.WiringSpec, serviceName string, latency string) {
 	serverWrapper := serviceName + ".server.latency"
 	ptr := pointer.GetPointer(spec, serviceName)
@@ -39,7 +41,7 @@ func AddFixed(spec wiring.WiringSpec, serviceName string, latency string) {
 		slog.Error("Unable to add a latencyinjector to " + serviceName + " as it is not a pointer")
 	}
 
-	serverNext := ptr.AddDstModifier(spec, serverWrapper)
+	serverNext := ptr.AddServerModifier(spec, serverWrapper)
 
 	spec.Define(serverWrapper, &LatencyInjectorWrapper{}, func(ns wiring.Namespace) (ir.IRNode, error) {
 		var wrapped golang.Service

--- a/plugins/memcached/wiring.go
+++ b/plugins/memcached/wiring.go
@@ -42,7 +42,7 @@ func Container(spec wiring.WiringSpec, cacheName string) string {
 	ptr.AddAddrModifier(spec, addrName)
 
 	// Define the memcached client add it to the client side of the pointer
-	clientNext := ptr.AddSrcModifier(spec, clientName)
+	clientNext := ptr.AddClientModifier(spec, clientName)
 	spec.Define(clientName, &MemcachedGoClient{}, func(namespace wiring.Namespace) (ir.IRNode, error) {
 		addr, err := address.Dial[*MemcachedContainer](namespace, clientNext)
 		if err != nil {

--- a/plugins/mongodb/wiring.go
+++ b/plugins/mongodb/wiring.go
@@ -44,7 +44,7 @@ func Container(spec wiring.WiringSpec, dbName string) string {
 	ptr.AddAddrModifier(spec, addrName)
 
 	// Define the MongoDB client and add it to the client side of the pointer
-	clientNext := ptr.AddSrcModifier(spec, clientName)
+	clientNext := ptr.AddClientModifier(spec, clientName)
 	spec.Define(clientName, &MongoDBGoClient{}, func(ns wiring.Namespace) (ir.IRNode, error) {
 		addr, err := address.Dial[*MongoDBContainer](ns, clientNext)
 		if err != nil {

--- a/plugins/mysql/wiring.go
+++ b/plugins/mysql/wiring.go
@@ -46,7 +46,7 @@ func Container(spec wiring.WiringSpec, dbName string) string {
 	ptr.AddAddrModifier(spec, addrName)
 
 	// Define the MySQL client and add it to the client side of the pointer
-	clientNext := ptr.AddSrcModifier(spec, clientName)
+	clientNext := ptr.AddClientModifier(spec, clientName)
 	spec.Define(clientName, &MySQLDBGoClient{}, func(ns wiring.Namespace) (ir.IRNode, error) {
 		addr, err := address.Dial[*MySQLDBContainer](ns, clientNext)
 		if err != nil {

--- a/plugins/opentelemetry/wiring.go
+++ b/plugins/opentelemetry/wiring.go
@@ -74,7 +74,7 @@ func instrument(spec wiring.WiringSpec, serviceName string, collectorName string
 	}
 
 	// Add the client wrapper to the pointer src
-	clientNext := ptr.AddSrcModifier(spec, clientWrapper)
+	clientNext := ptr.AddClientModifier(spec, clientWrapper)
 
 	// Define the client wrapper
 	spec.Define(clientWrapper, &OpenTelemetryClientWrapper{}, func(namespace wiring.Namespace) (ir.IRNode, error) {

--- a/plugins/opentelemetry/wiring.go
+++ b/plugins/opentelemetry/wiring.go
@@ -94,7 +94,7 @@ func instrument(spec wiring.WiringSpec, serviceName string, collectorName string
 	})
 
 	// Add the server wrapper to the pointer dst
-	serverNext := ptr.AddDstModifier(spec, serverWrapper)
+	serverNext := ptr.AddServerModifier(spec, serverWrapper)
 
 	// Define the server wrapper
 	spec.Define(serverWrapper, &OpenTelemetryServerWrapper{}, func(namespace wiring.Namespace) (ir.IRNode, error) {

--- a/plugins/rabbitmq/wiring.go
+++ b/plugins/rabbitmq/wiring.go
@@ -41,7 +41,7 @@ func Container(spec wiring.WiringSpec, name string, queue_name string) string {
 	ptr.AddAddrModifier(spec, addrName)
 
 	// Define the Rabbitmq client and add it to the client side of the pointer
-	clientNext := ptr.AddSrcModifier(spec, clientName)
+	clientNext := ptr.AddClientModifier(spec, clientName)
 	spec.Define(clientName, &RabbitmqGoClient{}, func(ns wiring.Namespace) (ir.IRNode, error) {
 		addr, err := address.Dial[*RabbitmqContainer](ns, clientNext)
 		if err != nil {

--- a/plugins/redis/wiring.go
+++ b/plugins/redis/wiring.go
@@ -43,7 +43,7 @@ func Container(spec wiring.WiringSpec, cacheName string) string {
 	ptr.AddAddrModifier(spec, addrName)
 
 	// Define the Redis client and add it to the client side of the pointer
-	clientNext := ptr.AddSrcModifier(spec, clientName)
+	clientNext := ptr.AddClientModifier(spec, clientName)
 	spec.Define(clientName, &RedisGoClient{}, func(ns wiring.Namespace) (ir.IRNode, error) {
 		addr, err := address.Dial[*RedisContainer](ns, clientNext)
 		if err != nil {

--- a/plugins/retries/wiring.go
+++ b/plugins/retries/wiring.go
@@ -37,7 +37,7 @@ func AddRetries(spec wiring.WiringSpec, serviceName string, max_retries int64) {
 		return
 	}
 
-	clientNext := ptr.AddSrcModifier(spec, clientWrapper)
+	clientNext := ptr.AddClientModifier(spec, clientWrapper)
 
 	spec.Define(clientWrapper, &RetrierClient{Max: max_retries}, func(ns wiring.Namespace) (ir.IRNode, error) {
 		var wrapped golang.Service
@@ -88,7 +88,7 @@ func AddRetriesWithFixedDelay(spec wiring.WiringSpec, serviceName string, max_re
 		return
 	}
 
-	clientNext := ptr.AddSrcModifier(spec, clientWrapper)
+	clientNext := ptr.AddClientModifier(spec, clientWrapper)
 
 	spec.Define(clientWrapper, &RetrierExponentialBackoffClient{}, func(ns wiring.Namespace) (ir.IRNode, error) {
 		var wrapped golang.Service
@@ -106,7 +106,7 @@ func AddRetriesWithFixedDelay(spec wiring.WiringSpec, serviceName string, max_re
 // Modifies the given service such that all clients to that service retry with exponential delay.
 // The `starting_delay` is the first delay to be used before retrying.
 // The retries continue until a `backoff_limit` of delay is reached
-// `useJitter` indicates whether to use jitter in the delay or not, 
+// `useJitter` indicates whether to use jitter in the delay or not,
 // jitter is a random value added to the delay.
 // Usage:
 //
@@ -120,7 +120,7 @@ func AddRetriesWithExponentialBackoff(spec wiring.WiringSpec, serviceName string
 		return
 	}
 
-	clientNext := ptr.AddSrcModifier(spec, clientWrapper)
+	clientNext := ptr.AddClientModifier(spec, clientWrapper)
 
 	spec.Define(clientWrapper, &RetrierExponentialBackoffClient{}, func(ns wiring.Namespace) (ir.IRNode, error) {
 		var wrapped golang.Service
@@ -149,7 +149,7 @@ func AddRetriesRetryRateLimit(spec wiring.WiringSpec, serviceName string, max_re
 		return
 	}
 
-	clientNext := ptr.AddSrcModifier(spec, clientWrapper)
+	clientNext := ptr.AddClientModifier(spec, clientWrapper)
 
 	spec.Define(clientWrapper, &RetrierRateLimiterClient{Max: max_retries, RetryRateLimit: retry_rate_limit}, func(ns wiring.Namespace) (ir.IRNode, error) {
 		var wrapped golang.Service

--- a/plugins/thrift/wiring.go
+++ b/plugins/thrift/wiring.go
@@ -58,7 +58,7 @@ func Deploy(spec wiring.WiringSpec, serviceName string) {
 	//
 	// The client-side modifier creates a Thrift client and dials the server address.
 	// It assumes the next src modifier node will be a golangThriftServer address.
-	clientNext := ptr.AddSrcModifier(spec, thrift_client)
+	clientNext := ptr.AddClientModifier(spec, thrift_client)
 	spec.Define(thrift_client, &golangThriftClient{}, func(namespace wiring.Namespace) (ir.IRNode, error) {
 		addr, err := address.Dial[*golangThriftServer](namespace, clientNext)
 		if err != nil {

--- a/plugins/timeouts/wiring.go
+++ b/plugins/timeouts/wiring.go
@@ -4,7 +4,8 @@
 // The plugin will generate a wrapper client class that will wait for a fixed amount of time (the specified timeout value) before canceling the context. Once the context is cancelled, the execution returns to the caller.
 //
 // Example Usage to add a "1s" timeout to each request:
-//  timeouts.Add(spec, "my_service", "1s")
+//
+//	timeouts.Add(spec, "my_service", "1s")
 package timeouts
 
 import (
@@ -23,7 +24,8 @@ import (
 // The `timeout` string must be a sequence of decimal numbers, each with optional fraction and a unit suffix, such as "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 //
 // Usage:
-//   Add(spec, "my_service", "1s")
+//
+//	Add(spec, "my_service", "1s")
 func Add(spec wiring.WiringSpec, serviceName string, timeout string) {
 	clientWrapper := serviceName + ".client.timeout"
 
@@ -32,7 +34,7 @@ func Add(spec wiring.WiringSpec, serviceName string, timeout string) {
 		slog.Error("Unable to add timeouts to " + serviceName + " as it is not a pointer")
 	}
 
-	clientNext := ptr.AddSrcModifier(spec, clientWrapper)
+	clientNext := ptr.AddClientModifier(spec, clientWrapper)
 
 	spec.Define(clientWrapper, &TimeoutClient{}, func(ns wiring.Namespace) (ir.IRNode, error) {
 		var wrapped golang.Service

--- a/plugins/workflow/wiring.go
+++ b/plugins/workflow/wiring.go
@@ -103,7 +103,7 @@ func Service[ServiceType any](spec wiring.WiringSpec, serviceName string, servic
 
 	// Add a "service.client" node for convenience
 	clientName := serviceName + ".client"
-	clientNext := ptr.AddSrcModifier(spec, clientName)
+	clientNext := ptr.AddClientModifier(spec, clientName)
 	spec.Define(clientName, &workflowClient{}, func(namespace wiring.Namespace) (ir.IRNode, error) {
 		client := &workflowClient{}
 		if err := initWorkflowNode[ServiceType](&client.workflowNode, clientName); err != nil {

--- a/plugins/xtrace/wiring.go
+++ b/plugins/xtrace/wiring.go
@@ -78,7 +78,7 @@ func Instrument(spec wiring.WiringSpec, serviceName string) {
 		slog.Error("Unable to deploy " + serviceName + " using XTrace as it is not a pointer")
 	}
 
-	clientNext := ptr.AddSrcModifier(spec, clientWrapper)
+	clientNext := ptr.AddClientModifier(spec, clientWrapper)
 	spec.Define(clientWrapper, &XtraceClientWrapper{}, func(ns wiring.Namespace) (ir.IRNode, error) {
 		var wrapped golang.Service
 		if err := ns.Get(clientNext, &wrapped); err != nil {
@@ -117,7 +117,7 @@ func Instrument(spec wiring.WiringSpec, serviceName string) {
 // The generated container has the name `serviceName`.
 // Usage:
 //
-//  xtrace.container(spec, "xtrace_server")
+//	xtrace.container(spec, "xtrace_server")
 func container(spec wiring.WiringSpec, serverName string) string {
 	// The nodes that we are defining
 	xtraceAddr := serverName + ".addr"
@@ -145,7 +145,7 @@ func container(spec wiring.WiringSpec, serverName string) string {
 	ptr.AddAddrModifier(spec, xtraceAddr)
 
 	// Define the X-Trace client and add it to the client side of the pointer
-	clientNext := ptr.AddSrcModifier(spec, xtraceClient)
+	clientNext := ptr.AddClientModifier(spec, xtraceClient)
 	spec.Define(xtraceClient, &XTraceClient{}, func(ns wiring.Namespace) (ir.IRNode, error) {
 		addr, err := address.Dial[*XTraceServerContainer](ns, clientNext)
 		if err != nil {
@@ -171,7 +171,7 @@ func container(spec wiring.WiringSpec, serverName string) string {
 //
 // # Wiring Spec Usage:
 //
-//   xtrace.Logger(spec, "my_process") // Define an xtrace-logger for the process `my_process`
+//	xtrace.Logger(spec, "my_process") // Define an xtrace-logger for the process `my_process`
 func Logger(spec wiring.WiringSpec, processName string) string {
 	logger := "xtrace_logger"
 	xtrace_server := container(spec, default_xtrace_server_name)

--- a/plugins/xtrace/wiring.go
+++ b/plugins/xtrace/wiring.go
@@ -94,7 +94,7 @@ func Instrument(spec wiring.WiringSpec, serviceName string) {
 		return newXtraceClientWrapper(clientWrapper, wrapped, xtraceClient)
 	})
 
-	serverNext := ptr.AddDstModifier(spec, serverWrapper)
+	serverNext := ptr.AddServerModifier(spec, serverWrapper)
 	spec.Define(serverWrapper, &XtraceServerWrapper{}, func(ns wiring.Namespace) (ir.IRNode, error) {
 		var wrapped golang.Service
 		if err := ns.Get(serverNext, &wrapped); err != nil {

--- a/plugins/zipkin/wiring.go
+++ b/plugins/zipkin/wiring.go
@@ -58,7 +58,7 @@ func Collector(spec wiring.WiringSpec, collectorName string) string {
 	ptr.AddAddrModifier(spec, collectorAddr)
 
 	// Define the Zipkin collector client and add it to the client side of the pointer
-	clientNext := ptr.AddSrcModifier(spec, collectorClient)
+	clientNext := ptr.AddClientModifier(spec, collectorClient)
 	spec.Define(collectorClient, &ZipkinCollectorClient{}, func(ns wiring.Namespace) (ir.IRNode, error) {
 		addr, err := address.Dial[*ZipkinCollectorContainer](ns, clientNext)
 		if err != nil {


### PR DESCRIPTION
## Related Issues
Closes #31

## Changes
- in pointer pkg, renamed `src` to `client`, `dst` to `server` using `Rename Symbol` in VSCode
- added `build` in .gitignore

## Testing
- building and running example projects still work