### PR TITLE
[Quality of Life] Remove all usage of fmt.Errorf, use errors.Errorf (in runtime code) or blueprint.Errorf (in compiler code) instead

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vs
+build

--- a/blueprint/pkg/wiring/application.go
+++ b/blueprint/pkg/wiring/application.go
@@ -1,8 +1,7 @@
 package wiring
 
 import (
-	"fmt"
-
+	"github.com/blueprint-uservices/blueprint/blueprint/pkg/blueprint"
 	"github.com/blueprint-uservices/blueprint/blueprint/pkg/ir"
 )
 
@@ -69,7 +68,7 @@ func (handler *applicationNamespaceHandler) Accepts(any) bool {
 
 // NamespaceHandler
 func (handler *applicationNamespaceHandler) AddEdge(name string, node ir.IRNode) error {
-	return fmt.Errorf("BlueprintApplication %v encountered unexpected edge %v %v", handler.app.ApplicationName, name, node)
+	return blueprint.Errorf("BlueprintApplication %v encountered unexpected edge %v %v", handler.app.ApplicationName, name, node)
 }
 
 // NamespaceHandler

--- a/blueprint/pkg/wiring/namespace.go
+++ b/blueprint/pkg/wiring/namespace.go
@@ -351,5 +351,5 @@ func (namespace *namespaceimpl) Error(message string, args ...any) error {
 	} else {
 		slog.Error(fmt.Sprintf("%s %s: %s", namespace.NamespaceType, namespace.Name(), formattedMessage))
 	}
-	return fmt.Errorf(formattedMessage)
+	return blueprint.Errorf(formattedMessage)
 }

--- a/examples/sockshop/tests/frontend_test.go
+++ b/examples/sockshop/tests/frontend_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/blueprint-uservices/blueprint/examples/sockshop/workflow/cart"
@@ -10,6 +9,7 @@ import (
 	"github.com/blueprint-uservices/blueprint/examples/sockshop/workflow/frontend"
 	"github.com/blueprint-uservices/blueprint/examples/sockshop/workflow/user"
 	"github.com/blueprint-uservices/blueprint/runtime/core/registry"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
 )
@@ -283,7 +283,7 @@ func initCatalogue() error {
 	for _, sock := range socks {
 		_, err := s.AddSock(ctx, sock)
 		if err != nil {
-			return fmt.Errorf("unable to add sock %v to catalogue due to %v", sock.Name, err.Error())
+			return errors.Errorf("unable to add sock %v to catalogue due to %v", sock.Name, err.Error())
 		}
 	}
 

--- a/examples/sockshop/workflow/frontend/frontend.go
+++ b/examples/sockshop/workflow/frontend/frontend.go
@@ -3,13 +3,13 @@ package frontend
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/blueprint-uservices/blueprint/examples/sockshop/workflow/cart"
 	"github.com/blueprint-uservices/blueprint/examples/sockshop/workflow/catalogue"
 	"github.com/blueprint-uservices/blueprint/examples/sockshop/workflow/order"
 	"github.com/blueprint-uservices/blueprint/examples/sockshop/workflow/user"
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 )
 
 type (
@@ -146,14 +146,14 @@ func (f *frontend) DeleteCart(ctx context.Context, sessionID string) error {
 // GetUser implements Frontend.
 func (f *frontend) GetUser(ctx context.Context, userID string) (user.User, error) {
 	if userID == "" {
-		return user.User{}, fmt.Errorf("no userID specified")
+		return user.User{}, errors.Errorf("no userID specified")
 	}
 
 	users, err := f.user.GetUsers(ctx, userID)
 	if err != nil {
 		return user.User{}, err
 	} else if len(users) == 0 {
-		return user.User{}, fmt.Errorf("invalid userID %v", userID)
+		return user.User{}, errors.Errorf("invalid userID %v", userID)
 	} else {
 		return users[0], nil
 	}
@@ -162,13 +162,13 @@ func (f *frontend) GetUser(ctx context.Context, userID string) (user.User, error
 // GetAddresses implements Frontend.
 func (f *frontend) GetAddress(ctx context.Context, addressID string) (user.Address, error) {
 	if addressID == "" {
-		return user.Address{}, fmt.Errorf("no addressID specified")
+		return user.Address{}, errors.Errorf("no addressID specified")
 	}
 	addrs, err := f.user.GetAddresses(ctx, addressID)
 	if err != nil {
 		return user.Address{}, err
 	} else if len(addrs) == 0 {
-		return user.Address{}, fmt.Errorf("invalid addressID %v", addressID)
+		return user.Address{}, errors.Errorf("invalid addressID %v", addressID)
 	} else {
 		return addrs[0], nil
 	}
@@ -177,13 +177,13 @@ func (f *frontend) GetAddress(ctx context.Context, addressID string) (user.Addre
 // GetCards implements Frontend.
 func (f *frontend) GetCard(ctx context.Context, cardID string) (user.Card, error) {
 	if cardID == "" {
-		return user.Card{}, fmt.Errorf("no cardID specified")
+		return user.Card{}, errors.Errorf("no cardID specified")
 	}
 	cards, err := f.user.GetCards(ctx, cardID)
 	if err != nil {
 		return user.Card{}, err
 	} else if len(cards) == 0 {
-		return user.Card{}, fmt.Errorf("invalid cardID %v", cardID)
+		return user.Card{}, errors.Errorf("invalid cardID %v", cardID)
 	} else {
 		return cards[0], nil
 	}
@@ -197,7 +197,7 @@ func (f *frontend) GetOrder(ctx context.Context, orderID string) (order.Order, e
 // GetOrders implements Frontend.
 func (f *frontend) GetOrders(ctx context.Context, userID string) ([]order.Order, error) {
 	if userID == "" {
-		return nil, fmt.Errorf("no userID specified")
+		return nil, errors.Errorf("no userID specified")
 	}
 	return f.order.GetOrders(ctx, userID)
 }

--- a/examples/sockshop/workflow/order/orderservice.go
+++ b/examples/sockshop/workflow/order/orderservice.go
@@ -6,7 +6,6 @@ package order
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/blueprint-uservices/blueprint/examples/sockshop/workflow/user"
 	"github.com/blueprint-uservices/blueprint/runtime/core/backend"
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
@@ -87,7 +87,7 @@ func (s *orderImpl) GetOrder(ctx context.Context, orderID string) (Order, error)
 		return Order{}, err
 	}
 	if !hasResult {
-		return Order{}, fmt.Errorf("order %v does not exist", orderID)
+		return Order{}, errors.Errorf("order %v does not exist", orderID)
 	}
 	return order, nil
 }
@@ -110,13 +110,13 @@ func (s *orderImpl) GetOrders(ctx context.Context, customerID string) ([]Order, 
 func (s *orderImpl) NewOrder(ctx context.Context, customerID, addressID, cardID, cartID string) (Order, error) {
 	// All arguments must be provided
 	if customerID == "" {
-		return Order{}, fmt.Errorf("missing customerID")
+		return Order{}, errors.Errorf("missing customerID")
 	} else if addressID == "" {
-		return Order{}, fmt.Errorf("missing addressID")
+		return Order{}, errors.Errorf("missing addressID")
 	} else if cardID == "" {
-		return Order{}, fmt.Errorf("missing cardID")
+		return Order{}, errors.Errorf("missing cardID")
 	} else if cartID == "" {
-		return Order{}, fmt.Errorf("missing cartID")
+		return Order{}, errors.Errorf("missing cartID")
 	}
 
 	// Fetch data concurrently
@@ -153,13 +153,13 @@ func (s *orderImpl) NewOrder(ctx context.Context, customerID, addressID, cardID,
 		return Order{}, err
 	}
 	if len(items) == 0 {
-		return Order{}, fmt.Errorf("no items in cart")
+		return Order{}, errors.Errorf("no items in cart")
 	} else if len(users) == 0 {
-		return Order{}, fmt.Errorf("unknown customer %v", customerID)
+		return Order{}, errors.Errorf("unknown customer %v", customerID)
 	} else if len(addresses) == 0 {
-		return Order{}, fmt.Errorf("invalid address %v", addressID)
+		return Order{}, errors.Errorf("invalid address %v", addressID)
 	} else if len(cards) == 0 {
-		return Order{}, fmt.Errorf("invalid card %v", cardID)
+		return Order{}, errors.Errorf("invalid card %v", cardID)
 	}
 
 	// Calculate total and authorize payment.
@@ -168,7 +168,7 @@ func (s *orderImpl) NewOrder(ctx context.Context, customerID, addressID, cardID,
 	if err != nil {
 		return Order{}, err
 	} else if !auth.Authorised {
-		return Order{}, fmt.Errorf("payment not authorized due to %v", auth.Message)
+		return Order{}, errors.Errorf("payment not authorized due to %v", auth.Message)
 	}
 
 	// Submit the shipment

--- a/examples/sockshop/workflow/payment/paymentservice.go
+++ b/examples/sockshop/workflow/payment/paymentservice.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+
+	errors_ "github.com/pkg/errors"
 )
 
 // PaymentService provides payment services
@@ -27,7 +29,7 @@ type Authorisation struct {
 func NewPaymentService(ctx context.Context, declineOverAmount string) (PaymentService, error) {
 	amount, err := strconv.ParseFloat(declineOverAmount, 32)
 	if err != nil {
-		return nil, fmt.Errorf("invalid declineOverAmount %v; expected a float32", declineOverAmount)
+		return nil, errors_.Errorf("invalid declineOverAmount %v; expected a float32", declineOverAmount)
 	}
 	return &paymentImpl{
 		declineOverAmount: float32(amount),

--- a/examples/sockshop/workflow/shipping/shippingservice.go
+++ b/examples/sockshop/workflow/shipping/shippingservice.go
@@ -7,9 +7,9 @@ package shipping
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/blueprint-uservices/blueprint/runtime/core/backend"
+	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
@@ -56,7 +56,7 @@ func (service *shippingImpl) PostShipping(ctx context.Context, shipment Shipment
 	if err != nil {
 		return shipment, err
 	} else if !shipped {
-		return shipment, fmt.Errorf("Unable to submit shipment %v %v to the shipping queue", shipment.ID, shipment.Name)
+		return shipment, errors.Errorf("Unable to submit shipment %v %v to the shipping queue", shipment.ID, shipment.Name)
 	}
 
 	// Insert into the shipment DB
@@ -74,7 +74,7 @@ func (s *shippingImpl) GetShipment(ctx context.Context, id string) (Shipment, er
 	if err != nil {
 		return Shipment{}, err
 	} else if !shipmentExists {
-		return Shipment{}, fmt.Errorf("unknown shipment %v", id)
+		return Shipment{}, errors.Errorf("unknown shipment %v", id)
 	}
 	return shipment, nil
 }
@@ -85,7 +85,7 @@ func (s *shippingImpl) UpdateStatus(ctx context.Context, id string, status strin
 	if err != nil {
 		return err
 	} else if updated == 0 {
-		return fmt.Errorf("unknown shipment %v", id)
+		return errors.Errorf("unknown shipment %v", id)
 	}
 	return nil
 }

--- a/examples/sockshop/workflow/user/userservice.go
+++ b/examples/sockshop/workflow/user/userservice.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/blueprint-uservices/blueprint/runtime/core/backend"
+	errors_ "github.com/pkg/errors"
 )
 
 type (
@@ -210,16 +211,16 @@ var (
 
 func (u *User) validate() error {
 	if u.FirstName == "" {
-		return fmt.Errorf(errMissingField, "FirstName")
+		return errors_.Errorf(errMissingField, "FirstName")
 	}
 	if u.LastName == "" {
-		return fmt.Errorf(errMissingField, "LastName")
+		return errors_.Errorf(errMissingField, "LastName")
 	}
 	if u.Username == "" {
-		return fmt.Errorf(errMissingField, "Username")
+		return errors_.Errorf(errMissingField, "Username")
 	}
 	if u.Password == "" {
-		return fmt.Errorf(errMissingField, "Password")
+		return errors_.Errorf(errMissingField, "Password")
 	}
 	return nil
 }

--- a/plugins/cmdbuilder/cmdbuilder.go
+++ b/plugins/cmdbuilder/cmdbuilder.go
@@ -59,6 +59,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/blueprint-uservices/blueprint/blueprint/pkg/blueprint"
 	"github.com/blueprint-uservices/blueprint/blueprint/pkg/blueprint/logging"
 	"github.com/blueprint-uservices/blueprint/blueprint/pkg/ir"
 	"github.com/blueprint-uservices/blueprint/blueprint/pkg/wiring"
@@ -146,17 +147,17 @@ func (b *CmdBuilder) ParseArgs() {
 
 func (b *CmdBuilder) ValidateArgs() error {
 	if b.OutputDir == "" {
-		return fmt.Errorf("output directory not specified, specify with -o")
+		return blueprint.Errorf("output directory not specified, specify with -o")
 	}
 
 	if b.SpecName == "" {
-		return fmt.Errorf("wiring spec not specified, specify with -w")
+		return blueprint.Errorf("wiring spec not specified, specify with -w")
 	}
 
 	if spec, specExists := b.Registry[b.SpecName]; specExists {
 		b.Spec = spec
 	} else {
-		return fmt.Errorf("unknown wiring spec \"%v\", expected one of:\n%v", b.SpecName, b.List())
+		return blueprint.Errorf("unknown wiring spec \"%v\", expected one of:\n%v", b.SpecName, b.List())
 	}
 
 	if b.Quiet {
@@ -191,7 +192,7 @@ func (b *CmdBuilder) Build() error {
 	b.Wiring = wiring.NewWiringSpec(b.Name)
 	nodesToBuild, err := b.Spec.Build(b.Wiring)
 	if err != nil {
-		return fmt.Errorf("unable to build %v-%v wiring due to %v", b.Name, b.SpecName, err.Error())
+		return blueprint.Errorf("unable to build %v-%v wiring due to %v", b.Name, b.SpecName, err.Error())
 	}
 	slog.Info(fmt.Sprintf("Constructed %v WiringSpec %v: \n%v", b.Name, b.SpecName, b.Wiring))
 
@@ -199,14 +200,14 @@ func (b *CmdBuilder) Build() error {
 	b.IR, err = b.Wiring.BuildIR(nodesToBuild...)
 	slog.Info(fmt.Sprintf("%v %v IR: \n%v", b.Name, b.SpecName, b.IR))
 	if err != nil {
-		return fmt.Errorf("unable to construct %v-%v IR due to %v", b.Name, b.SpecName, err.Error())
+		return blueprint.Errorf("unable to construct %v-%v IR due to %v", b.Name, b.SpecName, err.Error())
 	}
 
 	// Generate artifacts
 	slog.Info(fmt.Sprintf("Generating %v-%v artifacts to %v", b.Name, b.SpecName, b.OutputDir))
 	err = b.IR.GenerateArtifacts(b.OutputDir)
 	if err != nil {
-		return fmt.Errorf("unable to generate %v-%v artifacts due to %v", b.Name, b.SpecName, err.Error())
+		return blueprint.Errorf("unable to generate %v-%v artifacts due to %v", b.Name, b.SpecName, err.Error())
 	}
 
 	slog.Info(fmt.Sprintf("Successfully generated %v-%v to %v", b.Name, b.SpecName, b.OutputDir))

--- a/plugins/grpc/ir_grpc_client.go
+++ b/plugins/grpc/ir_grpc_client.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"fmt"
 
+	"github.com/blueprint-uservices/blueprint/blueprint/pkg/blueprint"
 	"github.com/blueprint-uservices/blueprint/blueprint/pkg/coreplugins/address"
 	"github.com/blueprint-uservices/blueprint/blueprint/pkg/coreplugins/service"
 	"github.com/blueprint-uservices/blueprint/blueprint/pkg/ir"
@@ -51,11 +52,11 @@ func (node *golangClient) GetInterface(ctx ir.BuildContext) (service.ServiceInte
 	}
 	grpc, isGrpc := iface.(*gRPCInterface)
 	if !isGrpc {
-		return nil, fmt.Errorf("grpc client expected a GRPC interface from %v but found %v", node.ServerAddr.Server.Name(), iface)
+		return nil, blueprint.Errorf("grpc client expected a GRPC interface from %v but found %v", node.ServerAddr.Server.Name(), iface)
 	}
 	wrapped, isValid := grpc.Wrapped.(*gocode.ServiceInterface)
 	if !isValid {
-		return nil, fmt.Errorf("grpc client expected the server's GRPC interface to wrap a gocode interface but found %v", grpc)
+		return nil, blueprint.Errorf("grpc client expected the server's GRPC interface to wrap a gocode interface but found %v", grpc)
 	}
 	return wrapped, nil
 }

--- a/plugins/healthchecker/ir.go
+++ b/plugins/healthchecker/ir.go
@@ -48,7 +48,7 @@ func (node *HealthCheckerServerWrapper) AddInterfaces(builder golang.ModuleBuild
 func newHealthCheckerServerWrapper(name string, server ir.IRNode) (*HealthCheckerServerWrapper, error) {
 	serverNode, is_callable := server.(golang.Service)
 	if !is_callable {
-		return nil, fmt.Errorf("healthchecker server wrapper requires %s to be a golang service but got %s", server.Name(), reflect.TypeOf(server).String())
+		return nil, blueprint.Errorf("healthchecker server wrapper requires %s to be a golang service but got %s", server.Name(), reflect.TypeOf(server).String())
 	}
 
 	node := &HealthCheckerServerWrapper{}

--- a/plugins/http/ir_http_client.go
+++ b/plugins/http/ir_http_client.go
@@ -3,6 +3,7 @@ package http
 import (
 	"fmt"
 
+	"github.com/blueprint-uservices/blueprint/blueprint/pkg/blueprint"
 	"github.com/blueprint-uservices/blueprint/blueprint/pkg/coreplugins/address"
 	"github.com/blueprint-uservices/blueprint/blueprint/pkg/coreplugins/service"
 	"github.com/blueprint-uservices/blueprint/blueprint/pkg/ir"
@@ -49,11 +50,11 @@ func (node *GolangHttpClient) GetInterface(ctx ir.BuildContext) (service.Service
 	}
 	http, isHttp := iface.(*HttpInterface)
 	if !isHttp {
-		return nil, fmt.Errorf("http client expected an HTTP interface from %v but found %v", node.ServerAddr.Name(), iface)
+		return nil, blueprint.Errorf("http client expected an HTTP interface from %v but found %v", node.ServerAddr.Name(), iface)
 	}
 	wrapped, isValid := http.Wrapped.(*gocode.ServiceInterface)
 	if !isValid {
-		return nil, fmt.Errorf("http client expected the server's HTTP interface to wrap a gocode interface but found %v", http)
+		return nil, blueprint.Errorf("http client expected the server's HTTP interface to wrap a gocode interface but found %v", http)
 	}
 	return wrapped, nil
 }

--- a/runtime/core/backend/reflect.go
+++ b/runtime/core/backend/reflect.go
@@ -1,14 +1,15 @@
 package backend
 
 import (
-	"fmt"
 	"reflect"
+
+	"github.com/pkg/errors"
 )
 
 func GetPointerValue(val any) (any, error) {
 	val_ptr := reflect.ValueOf(val)
 	if val_ptr.Kind() != reflect.Pointer {
-		return nil, fmt.Errorf("cannot indirect non-pointer type %v", val)
+		return nil, errors.Errorf("cannot indirect non-pointer type %v", val)
 	}
 	return reflect.Indirect(val_ptr).Interface(), nil
 }
@@ -21,7 +22,7 @@ src can be anything; dst must be a pointer to the same type as src
 func CopyResult(src any, dst any) error {
 	dst_ptr := reflect.ValueOf(dst)
 	if dst_ptr.Kind() != reflect.Pointer || dst_ptr.IsNil() {
-		return fmt.Errorf("unable to copy result to type %v", reflect.TypeOf(dst))
+		return errors.Errorf("unable to copy result to type %v", reflect.TypeOf(dst))
 	}
 	dst_val := reflect.Indirect(dst_ptr)
 	src_val := reflect.ValueOf(src)
@@ -41,7 +42,7 @@ func CopyResult(src any, dst any) error {
 		return nil
 	} else {
 		if !src_val.Type().AssignableTo(dst_val.Type()) {
-			return fmt.Errorf("unable to copy incompatible types %v and %v", src_val.Type(), dst_val.Type())
+			return errors.Errorf("unable to copy incompatible types %v and %v", src_val.Type(), dst_val.Type())
 		}
 		dst_val.Set(src_val)
 		return nil
@@ -54,7 +55,7 @@ Sets the zero value of a pointer
 func SetZero(dst any) error {
 	receiver_ptr := reflect.ValueOf(dst)
 	if receiver_ptr.Kind() != reflect.Pointer || receiver_ptr.IsNil() {
-		return fmt.Errorf("unable to copy result to type %v", reflect.TypeOf(dst))
+		return errors.Errorf("unable to copy result to type %v", reflect.TypeOf(dst))
 	}
 	reflect.Indirect(receiver_ptr).SetZero()
 	return nil

--- a/runtime/core/registry/registry.go
+++ b/runtime/core/registry/registry.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
 	"golang.org/x/exp/slog"
 )
 
@@ -53,13 +54,13 @@ func (r *ServiceRegistry[T]) Get(ctx context.Context) (T, error) {
 	r.isBuilt = true
 
 	if len(r.registered) == 0 {
-		r.buildError = fmt.Errorf("no clients registered for %v", r.name)
+		r.buildError = errors.Errorf("no clients registered for %v", r.name)
 		return r.built, r.buildError
 	}
 
 	buildFunc, hasDefault := r.registered[r.defaultBuildFunc]
 	if !hasDefault {
-		r.buildError = fmt.Errorf("no client called \"%v\" known for %v", r.defaultBuildFunc, r.name)
+		r.buildError = errors.Errorf("no client called \"%v\" known for %v", r.defaultBuildFunc, r.name)
 		return r.built, r.buildError
 	}
 

--- a/runtime/plugins/golang/namespace.go
+++ b/runtime/plugins/golang/namespace.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	"github.com/blueprint-uservices/blueprint/runtime/core/backend"
+	"github.com/pkg/errors"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slog"
 )
@@ -329,7 +330,7 @@ func (b *NamespaceBuilder) parseFlags() {
 		} else {
 			name := node.name
 			b.Define(node.name, func(n *Namespace) (any, error) {
-				return nil, fmt.Errorf("Required argument %v is not set", name)
+				return nil, errors.Errorf("Required argument %v is not set", name)
 			})
 		}
 	}
@@ -347,7 +348,7 @@ func (b *NamespaceBuilder) checkRequired(parent *Namespace) error {
 		missing = append(missing, node.name)
 	}
 	if len(missing) > 0 {
-		return fmt.Errorf("missing required argnodes [%v]", strings.Join(missing, ", "))
+		return errors.Errorf("missing required argnodes [%v]", strings.Join(missing, ", "))
 	}
 	return nil
 }
@@ -413,7 +414,7 @@ func (n *Namespace) Get(name string, receiver any) error {
 	if n.parent != nil {
 		return n.parent.Get(name, receiver)
 	}
-	return fmt.Errorf("%v unknown %v", n.name, name)
+	return errors.Errorf("%v unknown %v", n.name, name)
 }
 
 // ctx can be used by any [BuildFunc] that wants to start background goroutines,

--- a/runtime/plugins/golang/namespace_test.go
+++ b/runtime/plugins/golang/namespace_test.go
@@ -2,11 +2,11 @@ package golang_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/blueprint-uservices/blueprint/runtime/plugins/golang"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -144,7 +144,7 @@ func TestBuildError(t *testing.T) {
 
 	b.Define(key, func(n *golang.Namespace) (any, error) {
 		count = count + 1
-		return nil, fmt.Errorf("uhoh")
+		return nil, errors.Errorf("uhoh")
 	})
 	n, err := b.Build(context.Background())
 	assert.NoError(t, err)

--- a/runtime/plugins/simplecache/cache.go
+++ b/runtime/plugins/simplecache/cache.go
@@ -3,10 +3,10 @@ package simplecache
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/blueprint-uservices/blueprint/runtime/core/backend"
+	"github.com/pkg/errors"
 )
 
 // A simple map-based cache that implements the [backend.Cache] interface
@@ -39,7 +39,7 @@ func (cache *SimpleCache) Get(ctx context.Context, key string, val interface{}) 
 
 func (cache *SimpleCache) Mset(ctx context.Context, keys []string, values []interface{}) error {
 	if len(keys) != len(values) {
-		return fmt.Errorf("mset received %v keys but %v values", len(keys), len(values))
+		return errors.Errorf("mset received %v keys but %v values", len(keys), len(values))
 	}
 
 	for i, key := range keys {
@@ -53,7 +53,7 @@ func (cache *SimpleCache) Mset(ctx context.Context, keys []string, values []inte
 }
 func (cache *SimpleCache) Mget(ctx context.Context, keys []string, values []interface{}) error {
 	if len(keys) != len(values) {
-		return fmt.Errorf("mget received %v keys but %v values", len(keys), len(values))
+		return errors.Errorf("mget received %v keys but %v values", len(keys), len(values))
 	}
 
 	for i, key := range keys {

--- a/runtime/plugins/simplenosqldb/nosqldb.go
+++ b/runtime/plugins/simplenosqldb/nosqldb.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/blueprint-uservices/blueprint/runtime/core/backend"
 	"github.com/blueprint-uservices/blueprint/runtime/plugins/simplenosqldb/query"
+	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
@@ -71,7 +72,7 @@ func (c *SimpleCursor) One(ctx context.Context, obj interface{}) (bool, error) {
 func copyResult(src []bson.D, dst any) error {
 	dst_ptr := reflect.ValueOf(dst)
 	if dst_ptr.Kind() != reflect.Pointer || dst_ptr.IsNil() {
-		return fmt.Errorf("unable to copy result to type %v", reflect.TypeOf(dst))
+		return errors.Errorf("unable to copy result to type %v", reflect.TypeOf(dst))
 	}
 	dst_val := reflect.Indirect(dst_ptr)
 
@@ -88,7 +89,7 @@ func copyResult(src []bson.D, dst any) error {
 		return nil
 	}
 
-	return fmt.Errorf("cannot copy slice results to non-slice %v", dst)
+	return errors.Errorf("cannot copy slice results to non-slice %v", dst)
 }
 
 func (c *SimpleCursor) All(ctx context.Context, obj interface{}) error {

--- a/runtime/plugins/simplenosqldb/query/parseupdate.go
+++ b/runtime/plugins/simplenosqldb/query/parseupdate.go
@@ -1,10 +1,10 @@
 package query
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 
+	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
@@ -61,7 +61,7 @@ func ParseUpdate(update bson.D) (Update, error) {
 				updates = append(updates, adds...)
 			}
 		default:
-			return nil, fmt.Errorf("unsupported update op %v", op.Key)
+			return nil, errors.Errorf("unsupported update op %v", op.Key)
 		}
 	}
 	return UpdateAll(updates), nil
@@ -70,7 +70,7 @@ func ParseUpdate(update bson.D) (Update, error) {
 func parseSet(args any) ([]Update, error) {
 	d, isD := args.(bson.D)
 	if !isD {
-		return nil, fmt.Errorf("invalid $set operator; expected a bson.D, got %v", args)
+		return nil, errors.Errorf("invalid $set operator; expected a bson.D, got %v", args)
 	}
 	var updates []Update
 	for _, e := range d {
@@ -86,7 +86,7 @@ func parseSet(args any) ([]Update, error) {
 func parseUnset(args any) ([]Update, error) {
 	d, isD := args.(bson.D)
 	if !isD {
-		return nil, fmt.Errorf("invalid $unset operator; expected a bson.D, got %v", args)
+		return nil, errors.Errorf("invalid $unset operator; expected a bson.D, got %v", args)
 	}
 	var updates []Update
 	for _, e := range d {
@@ -98,7 +98,7 @@ func parseUnset(args any) ([]Update, error) {
 func parseInc(args any) ([]Update, error) {
 	d, isD := args.(bson.D)
 	if !isD {
-		return nil, fmt.Errorf("invalid $inc operator; expected a bson.D, got %v", args)
+		return nil, errors.Errorf("invalid $inc operator; expected a bson.D, got %v", args)
 	}
 	var updates []Update
 	for _, e := range d {
@@ -118,7 +118,7 @@ func parseInc(args any) ([]Update, error) {
 		// case float32:
 		// 	updates = append(updates, IncFloat(float64(v)))
 		default:
-			return nil, fmt.Errorf("invalid $inc argument; expect an int, got %v %v", reflect.TypeOf(e.Value), e.Value)
+			return nil, errors.Errorf("invalid $inc argument; expect an int, got %v %v", reflect.TypeOf(e.Value), e.Value)
 		}
 	}
 	return updates, nil
@@ -127,7 +127,7 @@ func parseInc(args any) ([]Update, error) {
 func parsePush(args any) ([]Update, error) {
 	d, isD := args.(bson.D)
 	if !isD {
-		return nil, fmt.Errorf("invalid $push operator; expected a bson.D, got %v", args)
+		return nil, errors.Errorf("invalid $push operator; expected a bson.D, got %v", args)
 	}
 	var updates []Update
 	for _, e := range d {
@@ -135,7 +135,7 @@ func parsePush(args any) ([]Update, error) {
 		if ed, eIsD := e.Value.(bson.D); eIsD {
 			for _, e2 := range ed {
 				if strings.HasPrefix(e2.Key, "$") {
-					return nil, fmt.Errorf("modifiers not currently supported for $push operation; got %v", e2)
+					return nil, errors.Errorf("modifiers not currently supported for $push operation; got %v", e2)
 				}
 			}
 		}
@@ -152,7 +152,7 @@ func parsePush(args any) ([]Update, error) {
 func parseAddToSet(args any) ([]Update, error) {
 	d, isD := args.(bson.D)
 	if !isD {
-		return nil, fmt.Errorf("invalid $addToSet operator; expected a bson.D, got %v", args)
+		return nil, errors.Errorf("invalid $addToSet operator; expected a bson.D, got %v", args)
 	}
 	var updates []Update
 	for _, e := range d {
@@ -160,7 +160,7 @@ func parseAddToSet(args any) ([]Update, error) {
 		if ed, eIsD := e.Value.(bson.D); eIsD {
 			for _, e2 := range ed {
 				if strings.HasPrefix(e2.Key, "$") {
-					return nil, fmt.Errorf("modifiers not currently supported for $push operation; got %v", e2)
+					return nil, errors.Errorf("modifiers not currently supported for $push operation; got %v", e2)
 				}
 			}
 		}
@@ -177,7 +177,7 @@ func parseAddToSet(args any) ([]Update, error) {
 func parsePull(args any) ([]Update, error) {
 	d, isD := args.(bson.D)
 	if !isD {
-		return nil, fmt.Errorf("invalid $pull operator; expected a bson.D, got %v", args)
+		return nil, errors.Errorf("invalid $pull operator; expected a bson.D, got %v", args)
 	}
 	var updates []Update
 	for _, e := range d {
@@ -185,7 +185,7 @@ func parsePull(args any) ([]Update, error) {
 		if ed, eIsD := e.Value.(bson.D); eIsD {
 			for _, e2 := range ed {
 				if strings.HasPrefix(e2.Key, "$") {
-					return nil, fmt.Errorf("modifiers not currently supported for $pull operation; got %v", e2)
+					return nil, errors.Errorf("modifiers not currently supported for $pull operation; got %v", e2)
 				}
 			}
 		}

--- a/runtime/plugins/simplenosqldb/query/update.go
+++ b/runtime/plugins/simplenosqldb/query/update.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/blueprint-uservices/blueprint/runtime/core/backend"
+	"github.com/pkg/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 )
@@ -172,12 +173,12 @@ func (s *set) Apply(itemRef any) error {
 
 	dst_ptr := reflect.ValueOf(itemRef)
 	if dst_ptr.Kind() != reflect.Pointer || dst_ptr.IsNil() {
-		return fmt.Errorf("set unable to apply update to non-pointer type %v", reflect.TypeOf(itemRef))
+		return errors.Errorf("set unable to apply update to non-pointer type %v", reflect.TypeOf(itemRef))
 	}
 	dst_val := reflect.Indirect(dst_ptr)
 
 	if dst_val.Kind() != reflect.Interface {
-		return fmt.Errorf("set unable to apply update to non-interface type %v", reflect.TypeOf(dst_val))
+		return errors.Errorf("set unable to apply update to non-interface type %v", reflect.TypeOf(dst_val))
 	}
 
 	dst_val.Set(reflect.ValueOf(v))
@@ -203,7 +204,7 @@ func (p *push) Apply(itemRef any) error {
 
 	a, isA := itemVal.(bson.A)
 	if !isA {
-		return fmt.Errorf("push expected a bson.A but instead found a %v %v", reflect.TypeOf(itemVal), itemVal)
+		return errors.Errorf("push expected a bson.A but instead found a %v %v", reflect.TypeOf(itemVal), itemVal)
 	}
 
 	a = append(a, v)
@@ -228,7 +229,7 @@ func (p *addtoset) Apply(itemRef any) error {
 
 	a, isA := itemVal.(bson.A)
 	if !isA {
-		return fmt.Errorf("expected a bson.A but instead found a %v %v", reflect.TypeOf(itemVal), itemVal)
+		return errors.Errorf("expected a bson.A but instead found a %v %v", reflect.TypeOf(itemVal), itemVal)
 	}
 
 	// Check if it exists
@@ -254,7 +255,7 @@ func (p *pull) Apply(itemRef any) error {
 
 	a, isA := itemVal.(bson.A)
 	if !isA {
-		return fmt.Errorf("pull expected a bson.A but instead found a %v %v", reflect.TypeOf(itemVal), itemVal)
+		return errors.Errorf("pull expected a bson.A but instead found a %v %v", reflect.TypeOf(itemVal), itemVal)
 	}
 
 	var updated bson.A
@@ -283,7 +284,7 @@ func (u *unsetfield) Apply(itemRef any) error {
 
 	v, isD := itemVal.(bson.D)
 	if !isD {
-		return fmt.Errorf("unsetfield expected a bson.D but instead found a %v %v", reflect.TypeOf(itemVal), itemVal)
+		return errors.Errorf("unsetfield expected a bson.D but instead found a %v %v", reflect.TypeOf(itemVal), itemVal)
 	}
 
 	// See if the key exists within the document; if so remove it
@@ -304,7 +305,7 @@ func (u *unsetelement) Apply(itemRef any) error {
 
 	v, isA := itemVal.(bson.A)
 	if !isA {
-		return fmt.Errorf("unsetelement expected a bson.A but instead found a %v %v", reflect.TypeOf(itemVal), itemVal)
+		return errors.Errorf("unsetelement expected a bson.A but instead found a %v %v", reflect.TypeOf(itemVal), itemVal)
 	}
 
 	// Ensure the slice length
@@ -340,7 +341,7 @@ func (i *incint) Apply(itemRef any) error {
 	case int:
 		return backend.CopyResult(v+int(i.amount), itemRef)
 	default:
-		return fmt.Errorf("incint unable to increment non-integer %v", itemVal)
+		return errors.Errorf("incint unable to increment non-integer %v", itemVal)
 	}
 }
 
@@ -356,7 +357,7 @@ func (s *updatefield) Apply(itemRef any) error {
 
 	v, isD := itemVal.(bson.D)
 	if !isD {
-		return fmt.Errorf("updatefield expected a bson.D but instead found a %v %v", reflect.TypeOf(itemVal), itemVal)
+		return errors.Errorf("updatefield expected a bson.D but instead found a %v %v", reflect.TypeOf(itemVal), itemVal)
 	}
 
 	// See if the key exists within the document; if so update in place
@@ -393,7 +394,7 @@ func (s *updateindex) Apply(itemRef any) error {
 
 	v, isA := itemVal.(bson.A)
 	if !isA {
-		return fmt.Errorf("updateindex expected a bson.A but instead found a %v %v", reflect.TypeOf(itemVal), itemVal)
+		return errors.Errorf("updateindex expected a bson.A but instead found a %v %v", reflect.TypeOf(itemVal), itemVal)
 	}
 
 	// Ensure the slice length
@@ -428,7 +429,7 @@ func (a *updateall) Apply(itemRef any) error {
 func (b *broadcastupdate) Apply(itemRef any) error {
 	item_ptr := reflect.ValueOf(itemRef)
 	if item_ptr.Kind() != reflect.Pointer {
-		return fmt.Errorf("broadcastupdate expect ptr type but got %v", reflect.TypeOf(itemRef))
+		return errors.Errorf("broadcastupdate expect ptr type but got %v", reflect.TypeOf(itemRef))
 	}
 	item_val := reflect.Indirect(item_ptr)
 


### PR DESCRIPTION
## Related Issues
Closes #116

## Changes
- in `examples/` and `runtime/`, replace `fmt.Errorf` with `errors.Errorf`
- in `blueprint/`, replace `fmt.Errorf` with `blueprint.Errorf`
- added `build` in .gitignore

## Testing
- building and running example projects still work