### PR TITLE
monitoring ctx.Done() to wake up early when ctrl+c

### DIFF
--- a/runtime/core/workload/engine.go
+++ b/runtime/core/workload/engine.go
@@ -103,7 +103,12 @@ func (e *Engine) RunOpenLoop(ctx context.Context) {
 	}()
 
 	// Sleep for the desired duration while the requests are launched in the background
-	time.Sleep(e.Duration)
+	sleep_timer := time.NewTimer(e.Duration)
+	defer sleep_timer.Stop()
+	select {
+	case <-ctx.Done():
+	case <-sleep_timer.C:
+	}
 	stop <- true
 	// Wait for all the launched routines to finish
 	wg.Wait()


### PR DESCRIPTION
The current `RunOpenLoop` function in `blueprint/runtime/core/workload/engine.go` doesn't monitor `ctx.Done()` channel, so even though `n.shutdown()` in `runtime/plugins/golang/namespace.go` is executed after `ctrl+c` is applied, the workload goroutine still keeps running. So all workloads generated by a workload generator using `RunOpenLoop` function can't be exited with `ctrl+c`.

To solve this, added a `select` logic to monitor `ctx.Done()`, and when an interrupt is detected, the goroutine will wake up earlier from sleep and exit gracefully.

This commit should solve [issue#189](https://github.com/Blueprint-uServices/blueprint/issues/189).