### PR TITLE
feat: make stdout metric print frequency configurable

### DIFF
--- a/examples/leaf/wiring/specs/http.go
+++ b/examples/leaf/wiring/specs/http.go
@@ -40,6 +40,7 @@ func makeHTTPSpec(spec wiring.WiringSpec) ([]string, error) {
 
 	nonleaf_service := workflow.Service[leaf.NonLeafService](spec, "nonleaf_service", leaf_service)
 	nonleaf_proc := applyHTTPDefaults(spec, nonleaf_service)
+	goproc.SetMetricPrintFrequency(spec, leaf_proc, "5s")
 
 	return []string{leaf_proc, nonleaf_proc}, nil
 }

--- a/plugins/goproc/metric.go
+++ b/plugins/goproc/metric.go
@@ -16,15 +16,17 @@ type stdoutMetricCollector struct {
 	service.ServiceNode
 	golang.Instantiable
 
-	CollectorName string
-	Spec          *workflowspec.Service
+	CollectorName  string
+	PrintFrequency string
+	Spec           *workflowspec.Service
 }
 
-func newStdOutMetricCollector(name string) (*stdoutMetricCollector, error) {
+func newStdOutMetricCollector(name string, printFrequency string) (*stdoutMetricCollector, error) {
 	spec, err := workflowspec.GetService[opentelemetry.StdoutMetricCollector]()
 	node := &stdoutMetricCollector{
-		CollectorName: name,
-		Spec:          spec,
+		CollectorName:  name,
+		PrintFrequency: printFrequency,
+		Spec:           spec,
 	}
 	return node, err
 }
@@ -62,7 +64,7 @@ func (node *stdoutMetricCollector) AddInstantiation(builder golang.NamespaceBuil
 
 	slog.Info(fmt.Sprintf("Instantiating StdoutMetricCollector %v in %v/%v", node.CollectorName, builder.Info().Package.PackageName, builder.Info().FileName))
 
-	return builder.DeclareConstructor(node.CollectorName, node.Spec.Constructor.AsConstructor(), []ir.IRNode{})
+	return builder.DeclareConstructor(node.CollectorName, node.Spec.Constructor.AsConstructor(), []ir.IRNode{&ir.IRValue{Value: node.PrintFrequency}})
 }
 
 func (node *stdoutMetricCollector) ImplementsGolangNode() {}

--- a/plugins/goproc/wiring.go
+++ b/plugins/goproc/wiring.go
@@ -185,11 +185,21 @@ func SetLogger(spec wiring.WiringSpec, procName string, loggerNodeName string) {
 	spec.SetProperty(procName, "logger", loggerNodeName)
 }
 
+// Set MetricPrintFrequency is not used directly by wiring specs; instead it is used bu other plugins such as
+// [opentelemetry] to configure the default metric collector.
+//
+// [opentelemetry]: https://github.com/Blueprint-uServices/blueprint/tree/main/plugins/opentelemetry
+func SetMetricPrintFrequency(spec wiring.WiringSpec, procName string, frequency string) {
+	spec.SetProperty(procName, "metricPrintFrequency", frequency)
+}
+
 // Defines the default metric collector
 func defineStdoutMetricCollector(spec wiring.WiringSpec, processName string) string {
 	collector := processName + ".stdoutmetriccollector"
 	spec.Define(collector, &stdoutMetricCollector{}, func(ns wiring.Namespace) (ir.IRNode, error) {
-		return newStdOutMetricCollector(collector)
+		var printFrequency string
+		spec.GetProperty(processName, "metricPrintFrequency", &printFrequency)
+		return newStdOutMetricCollector(collector, printFrequency)
 	})
 	return collector
 }

--- a/runtime/plugins/opentelemetry/metric.go
+++ b/runtime/plugins/opentelemetry/metric.go
@@ -19,16 +19,25 @@ func (s *StdoutMetricCollector) GetMetricProvider(ctx context.Context) (metric.M
 	return s.mp, nil
 }
 
-func NewStdoutMetricCollector(ctx context.Context) (*StdoutMetricCollector, error) {
+func NewStdoutMetricCollector(ctx context.Context, duration string) (*StdoutMetricCollector, error) {
 	exp, err := stdoutmetric.New()
+	if err != nil {
+		return nil, err
+	}
+
+	if duration == "" {
+		duration = "1s"
+	}
+
+	timerDuration, err := time.ParseDuration(duration)
 	if err != nil {
 		return nil, err
 	}
 
 	mp := metricsdk.NewMeterProvider(
 		metricsdk.WithReader(metricsdk.NewPeriodicReader(exp,
-			// Default is 1m. Set to 3s for demonstrative purposes.
-			metricsdk.WithInterval(3*time.Second))),
+			// Default is 1m. Set to 1s for demonstrative purposes.
+			metricsdk.WithInterval(timerDuration))),
 	)
 
 	otel.SetMeterProvider(mp)


### PR DESCRIPTION
# Summary
This PR makes the stdout metric collector print/export interval configurable at wiring time, instead of being fixed.

## What Changed

### Runtime

- Updated [metric.go](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) so [NewStdoutMetricCollector](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) accepts a duration string.

- Added parsing via [time.ParseDuration](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

- Added fallback default when empty duration is provided (1s).
### goproc plugin

- Updated [metric.go](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
    - added [PrintFrequency](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) field to the stdoutMetricCollector IR node
passed that value into the generated constructor call
    - Updated [wiring.go](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html):
    - added [SetMetricPrintFrequency(spec, procName, frequency string)](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
threaded metricPrintFrequency property into [defineStdoutMetricCollector](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

## Example update

- Updated [http.go](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) to demonstrate usage:
    - [goproc.SetMetricPrintFrequency(spec, leaf_proc, "5s")](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)

## Notes
Keeping the HTTP example change in this PR intentionally to show how users can configure the new setting.

Closes #205 